### PR TITLE
Recover ics

### DIFF
--- a/image/dockerfile
+++ b/image/dockerfile
@@ -4,12 +4,14 @@ RUN rm -r /srv/shiny-server
 WORKDIR /srv/shiny-server
 
 RUN git clone https://github.com/broadinstitute/dropviz.git .
-RUN mkdir -p www/cache/metacell
+RUN mkdir -p www/cache/metacells
 RUN mkdir -p www/downloads
+RUN mkdir -p www/cache/ic
 
 RUN chmod -R a+rwx www
 
 RUN gsutil -m rsync -r gs://dropviz-downloads/ www/downloads/
+RUN gsutil -m rsync -r gs://dropviz-ic/ www/ic/
 
 RUN echo "dropviz-bookmarks /var/lib/shiny-server/bookmarks/ gcsfuse rw,uid=999,gid=999" >> /etc/fstab
 COPY shiny-server.sh /bin

--- a/image/dockerfile
+++ b/image/dockerfile
@@ -11,7 +11,7 @@ RUN mkdir -p www/cache/ic
 RUN chmod -R a+rwx www
 
 RUN gsutil -m rsync -r gs://dropviz-downloads/ www/downloads/
-RUN gsutil -m rsync -r gs://dropviz-ic/ www/ic/
+RUN gsutil -m rsync -r gs://dropviz-ic/ www/cache/ic/
 
 RUN echo "dropviz-bookmarks /var/lib/shiny-server/bookmarks/ gcsfuse rw,uid=999,gid=999" >> /etc/fstab
 COPY shiny-server.sh /bin


### PR DESCRIPTION
Copy the pre-computed ICs from Google Storage bucket to local cache.
This should be part of persistent disk, like metacells.