### PR TITLE
Reduce cell size to minimum for tx.alpha

### DIFF
--- a/tSNE-plot.R
+++ b/tSNE-plot.R
@@ -70,7 +70,7 @@
       xy.gg <- (
         if (opt.show.cells) {
           if (opt.tx.alpha) {
-            geom_point(data=xy.data, aes(x=V1,y=V2,color=cx.permute(cx), alpha=alpha), size=opt.xy.cell.size) 
+            geom_point(data=xy.data, aes(x=V1,y=V2,color=cx.permute(cx), alpha=alpha), size=CELL.MIN.SIZE) 
           } else if (opt.tx.heat) {
             geom_point(data=xy.data, aes(x=V1,y=V2,color=heat), alpha=0.25, size=CELL.MIN.SIZE)
           } else {

--- a/tSNE.R
+++ b/tSNE.R
@@ -499,7 +499,7 @@ output$tsne.global.subcluster.label <- renderImage({
     img.sz <- tsne.image.size(facet1=region.count, facet2=gene.count, display.width=display.width)
     
   } else {
-    tsne.plot <- function(progress) plot.text("Highlight one or more regions, classes or clusters to begin subcluster analysis")
+    tsne.plot <- function(progress) plot.text("Limit to one or more regions, classes or clusters in the 'Query' panel to begin subcluster analysis")
     h <- img.size.round(session$clientData[[glue("output_tsne.global.subcluster.label_height")]])
     img.sz <- list(height=h,width=h)
   } 
@@ -532,7 +532,7 @@ output$tsne.local.label <- renderImage({
     img.sz <- tsne.image.size(facet1=cluster.count, facet2=gene.count, display.width=display.width)
 
   } else {
-    tsne.plot <- function(progress) plot.text("Highlight one or more regions, classes or clusters to begin subcluster analysis")
+    tsne.plot <- function(progress) plot.text("Limit to one or more regions, classes or clusters in the 'Query' panel to begin subcluster analysis")
     h <- img.size.round(session$clientData[[glue("output_tsne.local.label_height")]])
     img.sz <- list(height=h,width=h)
   }


### PR DESCRIPTION
When opt.tx.cells (showing diff exp for one or more genes), the possibly sampled cells may include non-expressing cells. These are colored with the category color and given a meta-cell alpha. Without bags, this is needed, but the size should be no bigger than the diff.data cells.
Even so, this is confusing - partly, I think, because the word "overlay" doesn't convey enough about the display and the user may assume that colored cells are all expressed or that the size indicates expression level.
Fixes #66 